### PR TITLE
Fix import data failing test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,9 +18,6 @@ Layout/LineLength:
 Layout/ElseAlignment:
   Enabled: false
 
-Layout/LineLength:
-  Max: 174
-
 Style/ConditionalAssignment:
   Enabled: false
 

--- a/staff_features/jobs/step_definitions/jobs.rb
+++ b/staff_features/jobs/step_definitions/jobs.rb
@@ -15,8 +15,17 @@ Then 'the Import Job page is displayed' do
 end
 
 Then 'the job completes' do
-  expect(page).not_to have_text 'This job is next in the queue.'
-  expect(page).to have_text 'The job has completed.'
+  tries = 0
+
+  begin
+    expect(page).to_not have_text 'This job is next in the queue.'
+    expect(page).to have_text 'The job has completed.'
+  rescue RSpec::Expectations::ExpectationNotMetError => e
+    tries += 1
+    sleep 3
+
+    raise e if tries == 5
+  end
 end
 
 Then 'the New & Modified Records section contains {int} links' do |number|

--- a/staff_features/jobs/step_definitions/jobs.rb
+++ b/staff_features/jobs/step_definitions/jobs.rb
@@ -15,16 +15,9 @@ Then 'the Import Job page is displayed' do
 end
 
 Then 'the job completes' do
-  tries = 0
-
-  begin
+  using_wait_time(15) do
     expect(page).to_not have_text 'This job is next in the queue.'
     expect(page).to have_text 'The job has completed.'
-  rescue RSpec::Expectations::ExpectationNotMetError => e
-    tries += 1
-    sleep 3
-
-    raise e if tries == 5
   end
 end
 


### PR DESCRIPTION
This test fails non-deterministically and causes frequent failures on the rest of the tests. A job can be finished in an arbitrary amount of time